### PR TITLE
Allow subview layering to be changed

### DIFF
--- a/OLEContainerScrollView/OLEContainerScrollView.h
+++ b/OLEContainerScrollView/OLEContainerScrollView.h
@@ -10,7 +10,8 @@
 
 @interface OLEContainerScrollView : UIScrollView
 
-- (void)addSubviewToContainer:(UIView *)subview;
-- (void)removeSubviewFromContainer:(UIView *)subview;
+// Add your subviews to contentView; OLEContainerScrollView will lay
+// them out vertically in the order in which they were added.
+@property (nonatomic, readonly) UIView *contentView;
 
 @end


### PR DESCRIPTION
I wanted to change the layering of the subviews so that the second
subview was behind the first subview (in my case, I have a UI element
in the first subview that deliberately oversteps bounds
for effect). However, simply sending the second subview to the back of
contentView changed the iteration order during the layout process,
causing the subviews to be visually reordered.

This change uses a mutable array to track the subview addition order
distinctly from the layering order, and allows bringSubviewToFront: and
sendSubviewToBack: to work as callers would expect.
