### PR TITLE
Take into account contentInset when setting the contentSize for the scrollView

### DIFF
--- a/OLEContainerScrollView/OLEContainerScrollView.m
+++ b/OLEContainerScrollView/OLEContainerScrollView.m
@@ -186,7 +186,7 @@ static void *KVOContext = &KVOContext;
         }
     }
     
-    self.contentSize = CGSizeMake(self.bounds.size.width, fmax(yOffsetOfCurrentSubview, self.bounds.size.height));
+    self.contentSize = CGSizeMake(self.bounds.size.width, fmax(yOffsetOfCurrentSubview, self.bounds.size.height - (self.contentInset.top + self.contentInset.bottom)));
 }
 
 @end


### PR DESCRIPTION
In iOS 7 contentInset is automatically added to scrollviews to handle the new navigation bar behavior.
