### PR TITLE
Fixing occasional wrong layout.

### DIFF
--- a/OLEContainerScrollView/OLEContainerScrollView.m
+++ b/OLEContainerScrollView/OLEContainerScrollView.m
@@ -201,7 +201,14 @@ static void *KVOContext = &KVOContext;
     // scrolling when it is not needed.
     CGFloat minimumContentHeight = self.bounds.size.height - (self.contentInset.top + self.contentInset.bottom);
 
+    CGPoint initialContentOffset = self.contentOffset;
     self.contentSize = CGSizeMake(self.bounds.size.width, fmax(yOffsetOfCurrentSubview, minimumContentHeight));
+    
+    // If contentOffset changes after contentSize change, we need to trigger layout update one more time.
+    if (!CGPointEqualToPoint(initialContentOffset, self.contentOffset)) {
+        [self setNeedsLayout];
+        [self layoutIfNeeded];
+    }
 }
 
 @end


### PR DESCRIPTION
Hi and thanks for useful project, it helped me a lot!

I've found an edge case and came up with quick and dirty fix for it, any improvements are appreciated.

Sometimes contentOffset of containerView, that is used for positioning of subviews during layout, is not final and may change after contentSize change. This can happen when containerView is scrolled to bottom and some cells are deleted from tableView, that is located at the bottom. This triggers layoutSubviews during which contentOffset contains not updated value.

Here is an example project: https://github.com/imaks/OLEContainerScrollViewBug