### PR TITLE
call super last to ensure KVO observations are removed before deallocation

### DIFF
--- a/OLEContainerScrollView/OLEContainerScrollViewContentView.m
+++ b/OLEContainerScrollView/OLEContainerScrollViewContentView.m
@@ -21,10 +21,10 @@
 
 - (void)willRemoveSubview:(UIView *)subview
 {
-    [super willRemoveSubview:subview];
     if ([self.superview isKindOfClass:[OLEContainerScrollView class]]) {
         [(OLEContainerScrollView *)self.superview willRemoveSubviewFromContainer:subview];
     }
+    [super willRemoveSubview:subview];
 }
 
 @end


### PR DESCRIPTION
We had a crash where iOS 9/10 devices were crashing because `OLEContainerScrollView` was still observing KVO properties on a subview as it was being deallocated, causing an exception to be raised in `NSKVODeallocate`.

Calling `willRemoveSubviewFromContainer:` before `[super willRemoveSubview:subview]` gives the `OLEContainerScrollView` an opportunity to deregister itself before it's too late.