### PR TITLE
Ensure observations are not added multiple times

### DIFF
--- a/OLEContainerScrollView/OLEContainerScrollView.m
+++ b/OLEContainerScrollView/OLEContainerScrollView.m
@@ -67,6 +67,14 @@
 {
     NSParameterAssert(subview != nil);
 
+    NSUInteger ix = [self.subviewsInLayoutOrder indexOfObjectIdenticalTo:subview];
+    if (ix != NSNotFound) {
+        [self.subviewsInLayoutOrder removeObjectAtIndex:ix];
+        [self.subviewsInLayoutOrder addObject:subview];
+        [self setNeedsLayout];
+        return;
+    }
+
     subview.autoresizingMask = UIViewAutoresizingNone;
 
     [self.subviewsInLayoutOrder addObject:subview];


### PR DESCRIPTION
In our app we are calling `addContentSubviewToTop:` on the same subview multiple times (to move the subview to top). This was causing KVO observations to be added multiple times for the same subview. This guards against this situation to not re-configure and re-observe the subview.